### PR TITLE
registering packages is not necessary and results in an error

### DIFF
--- a/md/first-time-with-pypi.md
+++ b/md/first-time-with-pypi.md
@@ -188,14 +188,10 @@ use the [MIT license](http://opensource.org/licenses/MIT).
 
 Run:
 
-    python setup.py register -r pypitest
-
-This will attempt to register your package against PyPI's test server, just to make sure you've
-set up everything correctly.
-
-Then, run:
-
     python setup.py sdist upload -r pypitest
+
+This will attempt to register your package against PyPI's test server and make sure you've
+set up everything correctly.
 
 You should get no errors, and should also now be able to see your library in the
 [test PyPI repository](https://testpypi.python.org/pypi).
@@ -203,12 +199,9 @@ You should get no errors, and should also now be able to see your library in the
 ### Upload to PyPI Live
 
 Once you've successfully uploaded to PyPI Test, perform the same steps but point to
-the live PyPI server instead. To register, run:
-
-    python setup.py register -r pypi
-
-Then, run:
+the live PyPI server instead. 
 
     python setup.py sdist upload -r pypi
 
 and you're done! Congratulations on successfully publishing your first package!
+

--- a/posts/first-time-with-pypi.html
+++ b/posts/first-time-with-pypi.html
@@ -196,27 +196,17 @@ If you don't <strong>have</strong> to use a markdown README file, I would recomm
 use the <a href="http://opensource.org/licenses/MIT">MIT license</a>.</p>
 <h3>Upload your package to PyPI Test</h3>
 <p>Run:</p>
-<div class="codehilite"><pre><span></span>python setup.py register -r pypitest
-</pre></div>
-
-
-<p>This will attempt to register your package against PyPI's test server, just to make sure you've
-set up everything correctly.</p>
-<p>Then, run:</p>
 <div class="codehilite"><pre><span></span>python setup.py sdist upload -r pypitest
 </pre></div>
 
 
+<p>This will attempt to register your package against PyPI's test server and make sure you've
+set up everything correctly.</p>
 <p>You should get no errors, and should also now be able to see your library in the
 <a href="https://testpypi.python.org/pypi">test PyPI repository</a>.</p>
 <h3>Upload to PyPI Live</h3>
 <p>Once you've successfully uploaded to PyPI Test, perform the same steps but point to
-the live PyPI server instead. To register, run:</p>
-<div class="codehilite"><pre><span></span>python setup.py register -r pypi
-</pre></div>
-
-
-<p>Then, run:</p>
+the live PyPI server instead. </p>
 <div class="codehilite"><pre><span></span>python setup.py sdist upload -r pypi
 </pre></div>
 


### PR DESCRIPTION
Project pre-registration is no longer required or supported, so continue directly to uploading files.

https://packaging.python.org/guides/migrating-to-pypi-org/#registering-package-names-metadata